### PR TITLE
feat : 채널 CRUD 기능 구현

### DIFF
--- a/src/main/java/foxcord/domain/channel/controller/ChannelController.java
+++ b/src/main/java/foxcord/domain/channel/controller/ChannelController.java
@@ -1,6 +1,7 @@
 package foxcord.domain.channel.controller;
 
 import foxcord.domain.channel.dto.request.ChannelSaveRequest;
+import foxcord.domain.channel.dto.request.ChannelUpdateRequest;
 import foxcord.domain.channel.dto.response.ChannelResponse;
 import foxcord.domain.channel.entity.Channel;
 import foxcord.domain.channel.service.ChannelService;
@@ -10,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -44,5 +46,13 @@ public class ChannelController {
     public ResponseEntity<Void> delete(@PathVariable("channelId") Long channelId) {
         channelService.delete(channelId);
         return ResponseEntity.noContent().build();
+    }
+
+    @PatchMapping("/{channelId}")
+    public ResponseEntity<ChannelResponse> update(@PathVariable("channelId") Long channelId,
+            @RequestBody ChannelUpdateRequest updateRequest) {
+        Channel updatedChannel = channelService.update(channelId, updateRequest);
+        ChannelResponse channelResponse = ChannelResponse.toDto(updatedChannel);
+        return ResponseEntity.ok(channelResponse);
     }
 }

--- a/src/main/java/foxcord/domain/channel/controller/ChannelController.java
+++ b/src/main/java/foxcord/domain/channel/controller/ChannelController.java
@@ -1,6 +1,6 @@
 package foxcord.domain.channel.controller;
 
-import foxcord.domain.channel.dto.request.ChannelSaveRequest;
+import foxcord.domain.channel.dto.request.ChannelCreateRequest;
 import foxcord.domain.channel.dto.request.ChannelUpdateRequest;
 import foxcord.domain.channel.dto.response.ChannelResponse;
 import foxcord.domain.channel.entity.Channel;
@@ -26,8 +26,8 @@ public class ChannelController {
     private final ChannelService channelService;
 
     @PostMapping
-    public ResponseEntity<Void> create(@RequestBody ChannelSaveRequest saveRequest) {
-        Long channelId = channelService.create(saveRequest);
+    public ResponseEntity<Void> create(@RequestBody ChannelCreateRequest createRequest) {
+        Long channelId = channelService.create(createRequest);
         return ResponseEntity.created(URI.create("/channel/" + channelId)).build();
     }
 

--- a/src/main/java/foxcord/domain/channel/controller/ChannelController.java
+++ b/src/main/java/foxcord/domain/channel/controller/ChannelController.java
@@ -1,10 +1,14 @@
 package foxcord.domain.channel.controller;
 
 import foxcord.domain.channel.dto.request.ChannelSaveRequest;
+import foxcord.domain.channel.dto.response.ChannelResponse;
+import foxcord.domain.channel.entity.Channel;
 import foxcord.domain.channel.service.ChannelService;
 import java.net.URI;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -21,5 +25,16 @@ public class ChannelController {
     public ResponseEntity<Void> create(@RequestBody ChannelSaveRequest saveRequest) {
         Long channelId = channelService.create(saveRequest);
         return ResponseEntity.created(URI.create("/channel/" + channelId)).build();
+    }
+
+    @GetMapping
+    public ResponseEntity<List<ChannelResponse>> getChannels() {
+        List<Channel> channels = channelService.findAll();
+
+        List<ChannelResponse> channelResponses = channels.stream()
+                .map(ChannelResponse::toDto)
+                .toList();
+
+        return ResponseEntity.ok(channelResponses);
     }
 }

--- a/src/main/java/foxcord/domain/channel/controller/ChannelController.java
+++ b/src/main/java/foxcord/domain/channel/controller/ChannelController.java
@@ -1,0 +1,25 @@
+package foxcord.domain.channel.controller;
+
+import foxcord.domain.channel.dto.request.ChannelSaveRequest;
+import foxcord.domain.channel.service.ChannelService;
+import java.net.URI;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/channel")
+public class ChannelController {
+
+    private final ChannelService channelService;
+
+    @PostMapping
+    public ResponseEntity<Void> create(@RequestBody ChannelSaveRequest saveRequest) {
+        Long channelId = channelService.create(saveRequest);
+        return ResponseEntity.created(URI.create("/channel/" + channelId)).build();
+    }
+}

--- a/src/main/java/foxcord/domain/channel/controller/ChannelController.java
+++ b/src/main/java/foxcord/domain/channel/controller/ChannelController.java
@@ -8,7 +8,9 @@ import java.net.URI;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -36,5 +38,11 @@ public class ChannelController {
                 .toList();
 
         return ResponseEntity.ok(channelResponses);
+    }
+
+    @DeleteMapping("/{channelId}")
+    public ResponseEntity<Void> delete(@PathVariable("channelId") Long channelId) {
+        channelService.delete(channelId);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/foxcord/domain/channel/dto/request/ChannelCreateRequest.java
+++ b/src/main/java/foxcord/domain/channel/dto/request/ChannelCreateRequest.java
@@ -3,7 +3,7 @@ package foxcord.domain.channel.dto.request;
 import foxcord.domain.channel.entity.Channel;
 import foxcord.domain.channel.entity.ChannelType;
 
-public record ChannelSaveRequest(
+public record ChannelCreateRequest(
         String name,
         String type
 ) {

--- a/src/main/java/foxcord/domain/channel/dto/request/ChannelSaveRequest.java
+++ b/src/main/java/foxcord/domain/channel/dto/request/ChannelSaveRequest.java
@@ -1,0 +1,14 @@
+package foxcord.domain.channel.dto.request;
+
+import foxcord.domain.channel.entity.Channel;
+import foxcord.domain.channel.entity.ChannelType;
+
+public record ChannelSaveRequest(
+        String name,
+        String type
+) {
+
+    public Channel toEntity() {
+        return new Channel(name, ChannelType.from(type));
+    }
+}

--- a/src/main/java/foxcord/domain/channel/dto/request/ChannelUpdateRequest.java
+++ b/src/main/java/foxcord/domain/channel/dto/request/ChannelUpdateRequest.java
@@ -1,0 +1,7 @@
+package foxcord.domain.channel.dto.request;
+
+public record ChannelUpdateRequest(
+        String newName
+) {
+
+}

--- a/src/main/java/foxcord/domain/channel/dto/response/ChannelResponse.java
+++ b/src/main/java/foxcord/domain/channel/dto/response/ChannelResponse.java
@@ -1,0 +1,15 @@
+package foxcord.domain.channel.dto.response;
+
+import foxcord.domain.channel.entity.Channel;
+
+public record ChannelResponse(
+        Long id,
+        String name,
+        String type
+) {
+
+    public static ChannelResponse toDto(Channel channel) {
+        return new ChannelResponse(channel.getId(), channel.getName(),
+                channel.getChannelType().getType());
+    }
+}

--- a/src/main/java/foxcord/domain/channel/entity/Channel.java
+++ b/src/main/java/foxcord/domain/channel/entity/Channel.java
@@ -1,0 +1,33 @@
+package foxcord.domain.channel.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Channel {
+
+    @Id
+    @Column(name = "channel_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+    @Enumerated(EnumType.STRING)
+    private ChannelType channelType;
+
+    public Channel(String name, ChannelType channelType) {
+        this.name = name;
+        this.channelType = channelType;
+    }
+}

--- a/src/main/java/foxcord/domain/channel/entity/Channel.java
+++ b/src/main/java/foxcord/domain/channel/entity/Channel.java
@@ -30,4 +30,8 @@ public class Channel {
         this.name = name;
         this.channelType = channelType;
     }
+
+    public void update(String newName) {
+        this.name = newName;
+    }
 }

--- a/src/main/java/foxcord/domain/channel/entity/ChannelType.java
+++ b/src/main/java/foxcord/domain/channel/entity/ChannelType.java
@@ -1,5 +1,7 @@
 package foxcord.domain.channel.entity;
 
+import java.util.Arrays;
+
 public enum ChannelType {
     TEXT("채팅"),
     VOICE("음성");
@@ -8,5 +10,12 @@ public enum ChannelType {
 
     ChannelType(String type) {
         this.type = type;
+    }
+
+    public static ChannelType from(String type) {
+        return Arrays.stream(ChannelType.values())
+                .filter(channelType -> channelType.type.equals(type))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("잘못된 채팅 종류입니다."));
     }
 }

--- a/src/main/java/foxcord/domain/channel/entity/ChannelType.java
+++ b/src/main/java/foxcord/domain/channel/entity/ChannelType.java
@@ -1,0 +1,12 @@
+package foxcord.domain.channel.entity;
+
+public enum ChannelType {
+    TEXT("채팅"),
+    VOICE("음성");
+
+    private final String type;
+
+    ChannelType(String type) {
+        this.type = type;
+    }
+}

--- a/src/main/java/foxcord/domain/channel/entity/ChannelType.java
+++ b/src/main/java/foxcord/domain/channel/entity/ChannelType.java
@@ -1,7 +1,9 @@
 package foxcord.domain.channel.entity;
 
 import java.util.Arrays;
+import lombok.Getter;
 
+@Getter
 public enum ChannelType {
     TEXT("채팅"),
     VOICE("음성");

--- a/src/main/java/foxcord/domain/channel/repository/ChannelRepository.java
+++ b/src/main/java/foxcord/domain/channel/repository/ChannelRepository.java
@@ -1,0 +1,8 @@
+package foxcord.domain.channel.repository;
+
+import foxcord.domain.channel.entity.Channel;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChannelRepository extends JpaRepository<Channel, Long> {
+
+}

--- a/src/main/java/foxcord/domain/channel/service/ChannelService.java
+++ b/src/main/java/foxcord/domain/channel/service/ChannelService.java
@@ -1,8 +1,12 @@
 package foxcord.domain.channel.service;
 
 import foxcord.domain.channel.dto.request.ChannelSaveRequest;
+import foxcord.domain.channel.entity.Channel;
+import java.util.List;
 
 public interface ChannelService {
 
     Long create(ChannelSaveRequest saveRequest);
+
+    List<Channel> findAll();
 }

--- a/src/main/java/foxcord/domain/channel/service/ChannelService.java
+++ b/src/main/java/foxcord/domain/channel/service/ChannelService.java
@@ -1,13 +1,13 @@
 package foxcord.domain.channel.service;
 
-import foxcord.domain.channel.dto.request.ChannelSaveRequest;
+import foxcord.domain.channel.dto.request.ChannelCreateRequest;
 import foxcord.domain.channel.dto.request.ChannelUpdateRequest;
 import foxcord.domain.channel.entity.Channel;
 import java.util.List;
 
 public interface ChannelService {
 
-    Long create(ChannelSaveRequest saveRequest);
+    Long create(ChannelCreateRequest createRequest);
 
     List<Channel> findAll();
 

--- a/src/main/java/foxcord/domain/channel/service/ChannelService.java
+++ b/src/main/java/foxcord/domain/channel/service/ChannelService.java
@@ -1,0 +1,8 @@
+package foxcord.domain.channel.service;
+
+import foxcord.domain.channel.dto.request.ChannelSaveRequest;
+
+public interface ChannelService {
+
+    Long create(ChannelSaveRequest saveRequest);
+}

--- a/src/main/java/foxcord/domain/channel/service/ChannelService.java
+++ b/src/main/java/foxcord/domain/channel/service/ChannelService.java
@@ -9,4 +9,6 @@ public interface ChannelService {
     Long create(ChannelSaveRequest saveRequest);
 
     List<Channel> findAll();
+
+    void delete(Long channelId);
 }

--- a/src/main/java/foxcord/domain/channel/service/ChannelService.java
+++ b/src/main/java/foxcord/domain/channel/service/ChannelService.java
@@ -1,6 +1,7 @@
 package foxcord.domain.channel.service;
 
 import foxcord.domain.channel.dto.request.ChannelSaveRequest;
+import foxcord.domain.channel.dto.request.ChannelUpdateRequest;
 import foxcord.domain.channel.entity.Channel;
 import java.util.List;
 
@@ -11,4 +12,6 @@ public interface ChannelService {
     List<Channel> findAll();
 
     void delete(Long channelId);
+
+    Channel update(Long channelId, ChannelUpdateRequest updateRequest);
 }

--- a/src/main/java/foxcord/domain/channel/service/ChannelServiceImpl.java
+++ b/src/main/java/foxcord/domain/channel/service/ChannelServiceImpl.java
@@ -1,0 +1,22 @@
+package foxcord.domain.channel.service;
+
+import foxcord.domain.channel.dto.request.ChannelSaveRequest;
+import foxcord.domain.channel.entity.Channel;
+import foxcord.domain.channel.repository.ChannelRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ChannelServiceImpl implements ChannelService {
+
+    private final ChannelRepository channelRepository;
+
+    @Override
+    @Transactional
+    public Long create(ChannelSaveRequest saveRequest) {
+        Channel savedChannel = channelRepository.save(saveRequest.toEntity());
+        return savedChannel.getId();
+    }
+}

--- a/src/main/java/foxcord/domain/channel/service/ChannelServiceImpl.java
+++ b/src/main/java/foxcord/domain/channel/service/ChannelServiceImpl.java
@@ -1,6 +1,7 @@
 package foxcord.domain.channel.service;
 
 import foxcord.domain.channel.dto.request.ChannelSaveRequest;
+import foxcord.domain.channel.dto.request.ChannelUpdateRequest;
 import foxcord.domain.channel.entity.Channel;
 import foxcord.domain.channel.repository.ChannelRepository;
 import java.util.List;
@@ -31,8 +32,20 @@ public class ChannelServiceImpl implements ChannelService {
     @Override
     @Transactional
     public void delete(Long channelId) {
-        Channel findChannel = channelRepository.findById(channelId)
-                .orElseThrow(() -> new NoSuchElementException("채널이 존재하지 않습니다. [ID] " + channelId));
+        Channel findChannel = findOne(channelId);
         channelRepository.delete(findChannel);
+    }
+
+    @Override
+    @Transactional
+    public Channel update(Long channelId, ChannelUpdateRequest updateRequest) {
+        Channel channel = findOne(channelId);
+        channel.update(updateRequest.newName());
+        return channel;
+    }
+
+    private Channel findOne(Long channelId) {
+        return channelRepository.findById(channelId)
+                .orElseThrow(() -> new NoSuchElementException("채널이 존재하지 않습니다. [ID] " + channelId));
     }
 }

--- a/src/main/java/foxcord/domain/channel/service/ChannelServiceImpl.java
+++ b/src/main/java/foxcord/domain/channel/service/ChannelServiceImpl.java
@@ -1,6 +1,6 @@
 package foxcord.domain.channel.service;
 
-import foxcord.domain.channel.dto.request.ChannelSaveRequest;
+import foxcord.domain.channel.dto.request.ChannelCreateRequest;
 import foxcord.domain.channel.dto.request.ChannelUpdateRequest;
 import foxcord.domain.channel.entity.Channel;
 import foxcord.domain.channel.repository.ChannelRepository;
@@ -19,8 +19,8 @@ public class ChannelServiceImpl implements ChannelService {
 
     @Override
     @Transactional
-    public Long create(ChannelSaveRequest saveRequest) {
-        Channel savedChannel = channelRepository.save(saveRequest.toEntity());
+    public Long create(ChannelCreateRequest createRequest) {
+        Channel savedChannel = channelRepository.save(createRequest.toEntity());
         return savedChannel.getId();
     }
 

--- a/src/main/java/foxcord/domain/channel/service/ChannelServiceImpl.java
+++ b/src/main/java/foxcord/domain/channel/service/ChannelServiceImpl.java
@@ -3,12 +3,14 @@ package foxcord.domain.channel.service;
 import foxcord.domain.channel.dto.request.ChannelSaveRequest;
 import foxcord.domain.channel.entity.Channel;
 import foxcord.domain.channel.repository.ChannelRepository;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class ChannelServiceImpl implements ChannelService {
 
     private final ChannelRepository channelRepository;
@@ -18,5 +20,10 @@ public class ChannelServiceImpl implements ChannelService {
     public Long create(ChannelSaveRequest saveRequest) {
         Channel savedChannel = channelRepository.save(saveRequest.toEntity());
         return savedChannel.getId();
+    }
+
+    @Override
+    public List<Channel> findAll() {
+        return channelRepository.findAll();
     }
 }

--- a/src/main/java/foxcord/domain/channel/service/ChannelServiceImpl.java
+++ b/src/main/java/foxcord/domain/channel/service/ChannelServiceImpl.java
@@ -4,6 +4,7 @@ import foxcord.domain.channel.dto.request.ChannelSaveRequest;
 import foxcord.domain.channel.entity.Channel;
 import foxcord.domain.channel.repository.ChannelRepository;
 import java.util.List;
+import java.util.NoSuchElementException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -25,5 +26,13 @@ public class ChannelServiceImpl implements ChannelService {
     @Override
     public List<Channel> findAll() {
         return channelRepository.findAll();
+    }
+
+    @Override
+    @Transactional
+    public void delete(Long channelId) {
+        Channel findChannel = channelRepository.findById(channelId)
+                .orElseThrow(() -> new NoSuchElementException("채널이 존재하지 않습니다. [ID] " + channelId));
+        channelRepository.delete(findChannel);
     }
 }

--- a/src/test/java/foxcord/domain/channel/entity/ChannelTypeTest.java
+++ b/src/test/java/foxcord/domain/channel/entity/ChannelTypeTest.java
@@ -1,0 +1,29 @@
+package foxcord.domain.channel.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class ChannelTypeTest {
+
+    @Test
+    @DisplayName("채널 종류가 채팅, 음성이 아닌 경우 예외가 발생한다")
+    void makeChannelTypeEx() {
+        assertThatThrownBy(() -> ChannelType.from("글자"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("채널 종류를 생성한다")
+    void makeChannel() {
+        //given,when
+        ChannelType text = ChannelType.from("채팅");
+        ChannelType voice = ChannelType.from("음성");
+
+        //then
+        assertThat(text).isEqualTo(ChannelType.TEXT);
+        assertThat(voice).isEqualTo(ChannelType.VOICE);
+    }
+}

--- a/src/test/java/foxcord/domain/channel/service/ChannelServiceTest.java
+++ b/src/test/java/foxcord/domain/channel/service/ChannelServiceTest.java
@@ -1,12 +1,15 @@
 package foxcord.domain.channel.service;
 
+import static java.lang.Long.MAX_VALUE;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import foxcord.domain.channel.dto.request.ChannelSaveRequest;
 import foxcord.domain.channel.entity.Channel;
 import foxcord.domain.channel.entity.ChannelType;
 import foxcord.domain.channel.repository.ChannelRepository;
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -55,5 +58,27 @@ class ChannelServiceTest {
         //then
         assertThat(channels).hasSize(2)
                 .containsExactly(channelA, channelB);
+    }
+
+    @Test
+    @DisplayName("채널을 삭제한다")
+    void deleteChannel() {
+        //given
+        Channel channel = new Channel("A", ChannelType.TEXT);
+        channelRepository.save(channel);
+
+        //when
+        channelService.delete(channel.getId());
+
+        //then
+        List<Channel> channels = channelRepository.findAll();
+        assertThat(channels).isEmpty();
+    }
+
+    @Test
+    @DisplayName("존재하지 않은 채널 삭제 시 예외가 발생한다")
+    void deleteChannelWithNotExist() {
+        assertThatThrownBy(() -> channelService.delete(MAX_VALUE))
+                .isInstanceOf(NoSuchElementException.class);
     }
 }

--- a/src/test/java/foxcord/domain/channel/service/ChannelServiceTest.java
+++ b/src/test/java/foxcord/domain/channel/service/ChannelServiceTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import foxcord.domain.channel.dto.request.ChannelSaveRequest;
+import foxcord.domain.channel.dto.request.ChannelUpdateRequest;
 import foxcord.domain.channel.entity.Channel;
 import foxcord.domain.channel.entity.ChannelType;
 import foxcord.domain.channel.repository.ChannelRepository;
@@ -79,6 +80,33 @@ class ChannelServiceTest {
     @DisplayName("존재하지 않은 채널 삭제 시 예외가 발생한다")
     void deleteChannelWithNotExist() {
         assertThatThrownBy(() -> channelService.delete(MAX_VALUE))
+                .isInstanceOf(NoSuchElementException.class);
+    }
+
+    @Test
+    @DisplayName("채널 이름을 수정한다")
+    void updateChannelName() {
+        //given
+        Channel channel = new Channel("A", ChannelType.TEXT);
+        channelRepository.save(channel);
+
+        ChannelUpdateRequest updateRequest = new ChannelUpdateRequest("B");
+
+        //when
+        channelService.update(channel.getId(), updateRequest);
+
+        //then
+        assertThat(channel.getName()).isEqualTo(updateRequest.newName());
+    }
+
+    @Test
+    @DisplayName("존재하지 않은 채널 수정 시 예외가 발생한다")
+    void updateChannelWithNotExist() {
+        //given
+        ChannelUpdateRequest updateRequest = new ChannelUpdateRequest("new");
+
+        //when, then
+        assertThatThrownBy(() -> channelService.update(MAX_VALUE, updateRequest))
                 .isInstanceOf(NoSuchElementException.class);
     }
 }

--- a/src/test/java/foxcord/domain/channel/service/ChannelServiceTest.java
+++ b/src/test/java/foxcord/domain/channel/service/ChannelServiceTest.java
@@ -6,6 +6,7 @@ import foxcord.domain.channel.dto.request.ChannelSaveRequest;
 import foxcord.domain.channel.entity.Channel;
 import foxcord.domain.channel.entity.ChannelType;
 import foxcord.domain.channel.repository.ChannelRepository;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -37,5 +38,22 @@ class ChannelServiceTest {
         assertThat(result).isPresent();
         assertThat(result.get().getName()).isEqualTo(saveRequest.name());
         assertThat(result.get().getChannelType()).isEqualTo(ChannelType.TEXT);
+    }
+
+    @Test
+    @DisplayName("채널 목록을 조회한다")
+    void findChannels() {
+        //given
+        Channel channelA = new Channel("A", ChannelType.TEXT);
+        Channel channelB = new Channel("B", ChannelType.VOICE);
+        channelRepository.save(channelA);
+        channelRepository.save(channelB);
+
+        //when
+        List<Channel> channels = channelService.findAll();
+
+        //then
+        assertThat(channels).hasSize(2)
+                .containsExactly(channelA, channelB);
     }
 }

--- a/src/test/java/foxcord/domain/channel/service/ChannelServiceTest.java
+++ b/src/test/java/foxcord/domain/channel/service/ChannelServiceTest.java
@@ -1,0 +1,41 @@
+package foxcord.domain.channel.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import foxcord.domain.channel.dto.request.ChannelSaveRequest;
+import foxcord.domain.channel.entity.Channel;
+import foxcord.domain.channel.entity.ChannelType;
+import foxcord.domain.channel.repository.ChannelRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@SpringBootTest
+class ChannelServiceTest {
+
+    @Autowired
+    ChannelService channelService;
+
+    @Autowired
+    ChannelRepository channelRepository;
+
+    @Test
+    @DisplayName("채널을 생성한다")
+    void createChannel() {
+        //given
+        ChannelSaveRequest saveRequest = new ChannelSaveRequest("A", "채팅");
+
+        //when
+        Long savedId = channelService.create(saveRequest);
+
+        //then
+        Optional<Channel> result = channelRepository.findById(savedId);
+        assertThat(result).isPresent();
+        assertThat(result.get().getName()).isEqualTo(saveRequest.name());
+        assertThat(result.get().getChannelType()).isEqualTo(ChannelType.TEXT);
+    }
+}

--- a/src/test/java/foxcord/domain/channel/service/ChannelServiceTest.java
+++ b/src/test/java/foxcord/domain/channel/service/ChannelServiceTest.java
@@ -4,7 +4,7 @@ import static java.lang.Long.MAX_VALUE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import foxcord.domain.channel.dto.request.ChannelSaveRequest;
+import foxcord.domain.channel.dto.request.ChannelCreateRequest;
 import foxcord.domain.channel.dto.request.ChannelUpdateRequest;
 import foxcord.domain.channel.entity.Channel;
 import foxcord.domain.channel.entity.ChannelType;
@@ -32,15 +32,15 @@ class ChannelServiceTest {
     @DisplayName("채널을 생성한다")
     void createChannel() {
         //given
-        ChannelSaveRequest saveRequest = new ChannelSaveRequest("A", "채팅");
+        ChannelCreateRequest createRequest = new ChannelCreateRequest("A", "채팅");
 
         //when
-        Long savedId = channelService.create(saveRequest);
+        Long savedId = channelService.create(createRequest);
 
         //then
         Optional<Channel> result = channelRepository.findById(savedId);
         assertThat(result).isPresent();
-        assertThat(result.get().getName()).isEqualTo(saveRequest.name());
+        assertThat(result.get().getName()).isEqualTo(createRequest.name());
         assertThat(result.get().getChannelType()).isEqualTo(ChannelType.TEXT);
     }
 


### PR DESCRIPTION
## 👀 관련 이슈

close #2 

## ✨ 작업 내용

<!-- 이번 PR에서 작업한 내용을 리스트 형식으로 작성해주세요. (이미지 첨부 가능) -->

- 채널 생성 기능을 구현하였습니다.
- 채널 이름 수정 기능을 구현하였습니다.
- 채널 목록 조회 기능을 구현하였습니다.
- 채널 삭제 기능을 구현하였습니다.

## 🛠️ 추후 진행해야할 사항

- 그룹과 연관관계 매핑
- 현재 사용자가 그룹장인지 여부에 따라 채널 CUD 예외 처리 진행
- 그룹장이 채널 생성 시 그룹의 최대 채널 수 검증 추가
  - 한 그룹 내에는 최대 `채팅 채널 5개`, `음성 채널 5개`을 생성할 수 있다.
- 채널 메세지 설계 후 채널 상세 조회 기능 구현